### PR TITLE
Add --include-dev option to `add`

### DIFF
--- a/lib/commands/add.js
+++ b/lib/commands/add.js
@@ -6,7 +6,6 @@ var rest = require('../rest'),
 
 module.exports = function (packageName) {
     var packages;
-
     if (typeof packageName === 'string') {
         packages = packageName.split(' ');
     } else {
@@ -14,6 +13,9 @@ module.exports = function (packageName) {
         if (fs.existsSync(pjPath)) {
             var pj = JSON.parse(fs.readFileSync(pjPath));
             packages = Object.keys(pj.dependencies);
+            if(packageName.includeDev && pj.devDependencies) {
+                packages += Object.keys(pj.devDependencies);
+            }
         }
     }
 

--- a/npm-onupdate.js
+++ b/npm-onupdate.js
@@ -15,14 +15,18 @@ if (notifier.update) {
     notifier.notify();
 }
 
+
+
 // Registering commainds
 program
     .command('add')
+    .option('--include-dev', 'Include devDependencies')
     .description('add alerts for all dependencies from package.info file in current dir')
     .action(function(){});
 
 program
     .command('add <package>')
+    .option('--include-dev')
     .description('add alert for specified package')
     .action(require('./lib/commands/add'));
 


### PR DESCRIPTION
This will add the devDependencies of a package
also to the list of packages to be notified.
Those two separate `add` command definitions is a bit
weird now because of the option.. (As the include-dev should only be active on the `add` without package). But it seems that it doesn't work otherwise.. :/
